### PR TITLE
Fix NPE when MDC context map is null

### DIFF
--- a/dropwizard-async-http-client/src/main/java/smartthings/dw/asynchttpclient/CorrelationIdFilter.java
+++ b/dropwizard-async-http-client/src/main/java/smartthings/dw/asynchttpclient/CorrelationIdFilter.java
@@ -8,6 +8,7 @@ import org.asynchttpclient.filter.RequestFilter;
 import org.slf4j.MDC;
 import smartthings.dw.logging.LoggingContext;
 
+import java.util.Collections;
 import java.util.Map;
 
 public class CorrelationIdFilter implements RequestFilter {
@@ -15,7 +16,7 @@ public class CorrelationIdFilter implements RequestFilter {
 	@Override
 	public <T> FilterContext<T> filter(FilterContext<T> ctx) throws FilterException {
 
-		final Map<String, String> mdc = MDC.getCopyOfContextMap();
+		final Map<String, String> mdc = getCopyOfContextMap();
 		final AsyncHandler<T> asyncHandler = ctx.getAsyncHandler();
 
 		// Wrap AsyncHandler to copy MDC since it executes on a different thread
@@ -84,4 +85,12 @@ public class CorrelationIdFilter implements RequestFilter {
 		}
 		return newContext;
 	}
+
+    /**
+     * Provides null safe access to MDC Context Map
+     */
+	private Map<String, String> getCopyOfContextMap() {
+        Map<String, String> context = MDC.getCopyOfContextMap();
+        return context == null ? Collections.emptyMap() : context;
+    }
 }


### PR DESCRIPTION
According to Slf4j Docs:

> public static Map<String,String> getCopyOfContextMap()
 Return a copy of the current thread's context map, with keys and values of type String. Returned value may be null.
 Returns:
 A copy of the current thread's context map. May be null.

http://www.slf4j.org/api/org/slf4j/MDC.html#getCopyOfContextMap()

