### PR TITLE
Fix errors when additional info contains null values

### DIFF
--- a/dropwizard-oauth/src/main/java/smartthings/dw/oauth/AuthResponse.java
+++ b/dropwizard-oauth/src/main/java/smartthings/dw/oauth/AuthResponse.java
@@ -103,6 +103,9 @@ public class AuthResponse {
         } else if (name.equals("scope")) {
             setScopes((List<String>) value);
         } else {
+            if (value == null) {
+                return;
+            }
             other.put(name, value);
         }
     }

--- a/dropwizard-oauth/src/main/java/smartthings/dw/oauth/OAuthToken.java
+++ b/dropwizard-oauth/src/main/java/smartthings/dw/oauth/OAuthToken.java
@@ -14,7 +14,7 @@ public class OAuthToken implements Principal, ScopeSupport {
     private final Set<String> scopes;
     private final String clientId;
     private final String authToken;
-    private final ImmutableMap<String, Object> additionalInformation;
+    private final Map<String, Object> additionalInformation;
 
     public OAuthToken(Optional<User> user,
                       Collection<String> scopes,
@@ -22,10 +22,11 @@ public class OAuthToken implements Principal, ScopeSupport {
                       String authToken,
                       Map additionalInformation) {
         this.user = user;
-        this.scopes = ImmutableSet.copyOf(scopes);
+        this.scopes = scopes == null ? Collections.emptySet() : ImmutableSet.copyOf(scopes);
         this.clientId = clientId;
         this.authToken = authToken;
-        this.additionalInformation = ImmutableMap.copyOf(additionalInformation);
+        this.additionalInformation = additionalInformation == null ?
+            Collections.emptyMap() : ImmutableMap.copyOf(additionalInformation);
     }
 
     @Override

--- a/dropwizard-oauth/src/test/groovy/smartthings/dw/oauth/SpringSecurityAuthenticatorSpec.groovy
+++ b/dropwizard-oauth/src/test/groovy/smartthings/dw/oauth/SpringSecurityAuthenticatorSpec.groovy
@@ -207,7 +207,8 @@ class SpringSecurityAuthenticatorSpec extends Specification {
 		  "authorities": ["ROLE_SUPPORT", "ROLE_SUPERUSER", "ROLE_APPROVER"],
 		  "email": "charlie.knudsen@smartthings.com",
 		  "client_id": "abcd",
-		  "principal": "device:1234"
+		  "principal": "device:1234",
+		  "badEntryShouldBeIgnored": null
 		}
 		"""
 


### PR DESCRIPTION
Currently the additional info code fails when OAuth check returns back keys without values.  This updates the deserialization mechanism to ignore key's w/ null values.