### PR TITLE
Upsert interceptor

### DIFF
--- a/dropwizard-cassandra/build.gradle
+++ b/dropwizard-cassandra/build.gradle
@@ -1,3 +1,18 @@
+buildscript {
+    repositories {
+        maven { url "https://maven.eveoh.nl/content/repositories/releases" }
+    }
+    dependencies {
+        classpath 'nl.eveoh:gradle-aspectj:1.6'
+    }
+}
+
+project.ext {
+    aspectjVersion = '1.8.10'
+}
+
+apply plugin: 'aspectj'
+
 dependencies {
 	compile project(':dropwizard-guice')
 
@@ -7,6 +22,8 @@ dependencies {
 	compile 'org.xerial.snappy:snappy-java:1.1.2'
 	compile 'org.hdrhistogram:HdrHistogram:2.1.8'
 	compile 'net.jpountz.lz4:lz4:1.3.0'
+    compile group: 'org.aspectj', name: 'aspectjrt', version: '1.8.10'
+    compile group: 'org.aspectj', name: 'aspectjweaver', version: '1.8.10'
 
 	testCompile 'org.spockframework:spock-core:1.0-groovy-2.4'
 	testRuntime 'cglib:cglib-nodep:2.2.2'

--- a/dropwizard-cassandra/src/main/java/smartthings/dw/cassandra/aspect/PruneCql.java
+++ b/dropwizard-cassandra/src/main/java/smartthings/dw/cassandra/aspect/PruneCql.java
@@ -1,0 +1,16 @@
+package smartthings.dw.cassandra.aspect;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation that helps to prune the cql statement generated from PreparedStatement.
+ * This will help eliminate tombstone creations in the cluster
+ */
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface PruneCql {
+}

--- a/dropwizard-cassandra/src/main/java/smartthings/dw/cassandra/aspect/PruneCqlAspect.java
+++ b/dropwizard-cassandra/src/main/java/smartthings/dw/cassandra/aspect/PruneCqlAspect.java
@@ -1,0 +1,166 @@
+package smartthings.dw.cassandra.aspect;
+
+import com.datastax.driver.core.*;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Singleton;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+
+/**
+ *
+ * Definition of Aspect for processing the Pointcuts. This is done by AspectJ weaver.
+ */
+
+@Aspect
+@Singleton
+public class PruneCqlAspect {
+
+    /**
+     * Check for any method that has {@link PruneCql} annotation on it.
+     */
+    @Pointcut("@annotation(smartthings.dw.cassandra.aspect.PruneCql)")
+    public void callPruneCql(){}
+
+    /**
+     * The annotation can be anywhere in the package. The requirement is that the method needs to return an
+     * implementation of {@link Statement}
+     */
+    @Pointcut("execution(* *(..))")
+    public void duringExecution(){}
+
+    /**
+     *
+     * @param joinPoint
+     * @return object ({@link Statement}
+     * @throws Throwable
+     */
+    @Around("callPruneCql() && duringExecution()")
+    public Object around(ProceedingJoinPoint joinPoint) throws Throwable {
+
+        if(!(joinPoint.proceed() instanceof Statement)){
+            return joinPoint.proceed();
+        }
+
+        BoundStatement incomingStatement = (BoundStatement) joinPoint.proceed();
+        PreparedStatement incomingPrep =  incomingStatement.preparedStatement();
+        String [] queryStringArray = incomingPrep.getQueryString().split(" ");
+        String firstWord = queryStringArray[0].toUpperCase();
+
+        if(firstWord.equals("INSERT")){
+            return evaluateInsert(incomingStatement);
+        }else{
+            return evaluateUpdate(incomingStatement);
+        }
+    }
+
+    /**
+     * Evaluates an Update CQL
+     *
+     * @param incomingStatement
+     * @return object ({@link Statement}
+     *
+     */
+     Statement evaluateUpdate(BoundStatement incomingStatement) {
+
+        PreparedStatement incomingPrep = incomingStatement.preparedStatement();
+
+        String tableName = incomingPrep.getVariables().getTable(0);
+
+        StringBuffer updateBuffer = new StringBuffer("UPDATE " + tableName + " SET ");
+
+        String queryString = incomingStatement.preparedStatement().getQueryString().toUpperCase();
+
+        String [] valuePairs = queryString.substring(queryString.indexOf("SET") + 3, queryString.indexOf("WHERE")).split(",");
+
+        ImmutableMap.Builder<String, Object> valueMapBuilder = ImmutableMap.builder();
+        ImmutableMap.Builder<String, Object> valueMapForWhereBuilder = ImmutableMap.builder();
+
+        int i = 0;
+        for (ColumnDefinitions.Definition definition : incomingPrep.getVariables()) {
+            Object valueObj = incomingStatement.getObject(definition.getName());
+            if(valueObj != null && i < valuePairs.length){
+                updateBuffer.append(valuePairs[i++]);
+                insertCommaSeparator(updateBuffer, valuePairs, i);
+                valueMapBuilder.put(definition.getName(), valueObj);
+            }else if(valueObj != null && i>= valuePairs.length){
+                valueMapForWhereBuilder.put(definition.getName(), valueObj);
+            }else if(valueObj == null){
+                i+=1;
+            }
+        }
+
+        if(valueMapBuilder.build().size() == valuePairs.length){
+            return incomingStatement;
+        }
+
+        String whereBuffer = queryString.substring(queryString.indexOf("WHERE"), queryString.length());
+
+        String finalQueryString = updateBuffer.append(" " + whereBuffer).toString();
+
+        SimpleStatement statement = new SimpleStatement(finalQueryString, valueMapBuilder.putAll(valueMapForWhereBuilder.build()).build());
+
+        return statement;
+
+    }
+
+    /**
+     * Evaluates an INSERT CQL
+     *
+     * @param incomingStatement
+     * @return
+     */
+     Statement evaluateInsert(BoundStatement incomingStatement) {
+
+        PreparedStatement incomingPrep = incomingStatement.preparedStatement();
+
+        String tableName = incomingPrep.getVariables().getTable(0);
+
+        StringBuffer insertBuffer = new StringBuffer("INSERT INTO " + tableName + " (");
+
+        StringBuffer valuesBuffer = new StringBuffer(" VALUES (");
+
+        String queryString = incomingStatement.preparedStatement().getQueryString().toUpperCase();
+        String [] columns = queryString.substring(queryString.indexOf("(") + 1, queryString.indexOf(")")).split(",");
+
+        ImmutableMap.Builder<String, Object> valueMapBuilder = ImmutableMap.builder();
+
+        int i = 0;
+        for (ColumnDefinitions.Definition definition : incomingPrep.getVariables()) {
+            Object valueObj = incomingStatement.getObject(definition.getName());
+            if(valueObj != null){
+                insertBuffer.append(columns[i++]);
+                insertCommaSeparator(insertBuffer, columns, i);
+                valuesBuffer.append(":" + definition.getName());
+                insertCommaSeparator(valuesBuffer, columns, i);
+                valueMapBuilder.put(definition.getName(), valueObj);
+            }else{
+                i+=1;
+            }
+        }
+
+        if(valueMapBuilder.build().size() == columns.length){
+            return incomingStatement;
+        }
+
+        String finalQueryString = insertBuffer.append(")").append(valuesBuffer).append(")").toString();
+
+        SimpleStatement statement = new SimpleStatement(finalQueryString, valueMapBuilder.build());
+
+        return statement;
+    }
+
+    /**
+     * Convenience method
+     * @param insertBuffer
+     * @param columns
+     * @param i
+     */
+    private void insertCommaSeparator(StringBuffer insertBuffer, String[] columns, int i) {
+        if(i < columns.length){
+            insertBuffer.append(",");
+        }
+    }
+
+}

--- a/dropwizard-cassandra/src/test/groovy/smartthings/dw/cassandra/aspect/PruneCqlAspectTest.groovy
+++ b/dropwizard-cassandra/src/test/groovy/smartthings/dw/cassandra/aspect/PruneCqlAspectTest.groovy
@@ -1,0 +1,142 @@
+package smartthings.dw.cassandra.aspect
+
+import com.datastax.driver.core.BoundStatement
+import com.datastax.driver.core.ColumnDefinitions
+import com.datastax.driver.core.DataType
+import com.datastax.driver.core.PreparedStatement
+import com.datastax.driver.core.SimpleStatement
+import org.aspectj.lang.ProceedingJoinPoint
+import spock.lang.Specification
+
+
+
+class PruneCqlAspectTest extends Specification {
+
+    BoundStatement boundStatement
+    PreparedStatement preparedStatement
+    PruneCqlAspect pruneCqlAspect
+    ProceedingJoinPoint proceedingJoinPoint
+    ColumnDefinitions columnDefinitions
+    ColumnDefinitions.Definition definition1
+    ColumnDefinitions.Definition definition2
+    ColumnDefinitions.Definition definition3
+    Iterator<ColumnDefinitions.Definition> iterator
+    ColumnDefinitions.Definition [] definitionArray
+
+    def setup () {
+        boundStatement = Mock()
+        preparedStatement = Mock()
+        proceedingJoinPoint = Mock()
+        columnDefinitions = Mock()
+
+        pruneCqlAspect = new PruneCqlAspect()
+    }
+
+    def "should return the incoming BoundStatement when no values are null for insert"(){
+
+        given:
+        definition1 = new ColumnDefinitions.Definition("marconi", "device", "hubid", DataType.varchar())
+        definition2 = new ColumnDefinitions.Definition("marconi", "device", "deviceid", DataType.varchar())
+        definition3 = new ColumnDefinitions.Definition("marconi", "device", "canopyid", DataType.varchar())
+        definitionArray = new ColumnDefinitions.Definition [3]
+        definitionArray.putAt(0, definition1)
+        definitionArray.putAt(1, definition2)
+        definitionArray.putAt(2, definition3)
+        iterator = definitionArray.iterator()
+        proceedingJoinPoint.proceed() >> boundStatement
+        boundStatement.preparedStatement() >> preparedStatement
+        preparedStatement.getQueryString() >> "INSERT INTO table(hub_id, device_id, canopy_id) VALUES (:hubid, :deviceid, :canopyid)"
+        preparedStatement.getVariables() >> columnDefinitions
+        columnDefinitions.iterator() >> iterator
+        boundStatement.getObject("hubid") >> "1"
+        boundStatement.getObject("deviceid") >> "2"
+        boundStatement.getObject("canopyid") >> "3"
+
+        when:
+         def returnObj = pruneCqlAspect.around(proceedingJoinPoint)
+
+        then:
+        assert returnObj instanceof BoundStatement
+    }
+
+    def "should return the incoming BoundStatement when some values are null for insert"(){
+
+        given:
+        definition1 = new ColumnDefinitions.Definition("marconi", "device", "hubid", DataType.varchar())
+        definition2 = new ColumnDefinitions.Definition("marconi", "device", "deviceid", DataType.varchar())
+        definition3 = new ColumnDefinitions.Definition("marconi", "device", "canopyid", DataType.varchar())
+        definitionArray = new ColumnDefinitions.Definition [3]
+        definitionArray.putAt(0, definition1)
+        definitionArray.putAt(1, definition2)
+        definitionArray.putAt(2, definition3)
+        iterator = definitionArray.iterator()
+        proceedingJoinPoint.proceed() >> boundStatement
+        boundStatement.preparedStatement() >> preparedStatement
+        preparedStatement.getQueryString() >> "INSERT INTO table(hub_id, device_id, canopy_id) VALUES (:hubid, :deviceid, :canopyid)"
+        preparedStatement.getVariables() >> columnDefinitions
+        columnDefinitions.iterator() >> iterator
+        boundStatement.getObject("hubid") >> "1"
+        boundStatement.getObject("deviceid") >> "2"
+        boundStatement.getObject("canopyid") >> null
+
+        when:
+        def returnObj = pruneCqlAspect.around(proceedingJoinPoint)
+
+        then:
+        assert returnObj instanceof SimpleStatement
+    }
+
+    def "should return the incoming BoundStatement when no values are null for update"(){
+
+        given:
+        definition1 = new ColumnDefinitions.Definition("marconi", "device", "deviceid", DataType.varchar())
+        definition2 = new ColumnDefinitions.Definition("marconi", "device", "canopyid", DataType.varchar())
+        definition3 = new ColumnDefinitions.Definition("marconi", "device", "hubid", DataType.varchar())
+        definitionArray = new ColumnDefinitions.Definition [3]
+        definitionArray.putAt(0, definition1)
+        definitionArray.putAt(1, definition2)
+        definitionArray.putAt(2, definition3)
+        iterator = definitionArray.iterator()
+        proceedingJoinPoint.proceed() >> boundStatement
+        boundStatement.preparedStatement() >> preparedStatement
+        preparedStatement.getQueryString() >> "UPDATE INTO table SET device_id = :deviceId, canopy_id = :canopyId WHERE hub_id = :hubId"
+        preparedStatement.getVariables() >> columnDefinitions
+        columnDefinitions.iterator() >> iterator
+        boundStatement.getObject("hubid") >> "1"
+        boundStatement.getObject("deviceid") >> "2"
+        boundStatement.getObject("canopyid") >> "3"
+
+        when:
+        def returnObj = pruneCqlAspect.around(proceedingJoinPoint)
+
+        then:
+        assert returnObj instanceof BoundStatement
+    }
+
+    def "should return the incoming BoundStatement when some values are null for update"(){
+
+        given:
+        definition1 = new ColumnDefinitions.Definition("marconi", "device", "deviceid", DataType.varchar())
+        definition2 = new ColumnDefinitions.Definition("marconi", "device", "canopyid", DataType.varchar())
+        definition3 = new ColumnDefinitions.Definition("marconi", "device", "hubid", DataType.varchar())
+        definitionArray = new ColumnDefinitions.Definition [3]
+        definitionArray.putAt(0, definition1)
+        definitionArray.putAt(1, definition2)
+        definitionArray.putAt(2, definition3)
+        iterator = definitionArray.iterator()
+        proceedingJoinPoint.proceed() >> boundStatement
+        boundStatement.preparedStatement() >> preparedStatement
+        preparedStatement.getQueryString() >> "UPDATE INTO table SET device_id = :deviceId, canopy_id = :canopyId WHERE hub_id = :hubId"
+        preparedStatement.getVariables() >> columnDefinitions
+        columnDefinitions.iterator() >> iterator
+        boundStatement.getObject("hubid") >> "1"
+        boundStatement.getObject("deviceid") >> "2"
+        boundStatement.getObject("canopyid") >> null
+
+        when:
+        def returnObj = pruneCqlAspect.around(proceedingJoinPoint)
+
+        then:
+        assert returnObj instanceof SimpleStatement
+    }
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,4 +1,4 @@
-#Thu Jan 12 16:16:53 PST 2017
+#Tue Aug 15 20:19:27 PDT 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Feature will prune the CQL before being sent to Cassandra Cluster. This will remove the elements that are set to null.  The usage in the application will look something like

@PruneCql
	private Statement insertDevice(Device device){
		Statement statement = deviceAccessor.insertDevice(device.getHubId(), device.getDeviceId(), device.getCanopyDeviceId(),
				device.getCreatedAt().toDate());

		return statement;
	}

The code uses Aspectj's Aspect. This can be either compile time weaved or run time weaved. Runtime weaving will require AspectJweaver.jar in the classpath and need to be passed as a javaagent to the java process.