### PR TITLE
Pull latest version of cassandra-migration.

### DIFF
--- a/dropwizard-cassandra/build.gradle
+++ b/dropwizard-cassandra/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
 	compile project(':dropwizard-guice')
 
-	compile "smartthings:cassandra-migration:0.1.0"
+	compile "smartthings:cassandra-migration:0.1.2"
 	compile "com.datastax.cassandra:cassandra-driver-core:${cassandraDriverVersion}"
 	compile "com.datastax.cassandra:cassandra-driver-mapping:${cassandraDriverVersion}"
 	compile 'org.xerial.snappy:snappy-java:1.1.2'


### PR DESCRIPTION
Fix an issue related to schema changes in Cassandra getting stuck by
failing silently, yet marking the migration successful.

* SmartThingsOSS/cassandra-migration#10
* SmartThingsOSS/cassandra-migration#11