### PR TITLE
NOV-52 Fine grained scope check via annotation for DropWizard resources

### DIFF
--- a/dropwizard-oauth/src/main/java/smartthings/dw/oauth/scope/FineGrainedScopeAllowed.java
+++ b/dropwizard-oauth/src/main/java/smartthings/dw/oauth/scope/FineGrainedScopeAllowed.java
@@ -1,0 +1,27 @@
+package smartthings.dw.oauth.scope;
+
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Allows to specify allowed scopes for resource classes or methods that follow the fine grained scope format and
+ * also can dynamically match the scope against a request's context parameters.
+ *
+ * To specify a scope that should match dynamically against the context parameters the scope must be written similar
+ * to DropWizard's URI template parameters, where the name of the context variable should be in be between curly braces.
+ *
+ * varInfo must be specified, which will indicate the name of the variable and where in the context can it be obtained
+ * from (e.g. path, query or headers).
+ */
+@Repeatable(FineGrainedScopesAllowed.class)
+@Retention(RUNTIME)
+@Target({TYPE, METHOD})
+public @interface FineGrainedScopeAllowed {
+    String scope();
+    VarInfo[] varInfo();
+}

--- a/dropwizard-oauth/src/main/java/smartthings/dw/oauth/scope/FineGrainedScopesAllowed.java
+++ b/dropwizard-oauth/src/main/java/smartthings/dw/oauth/scope/FineGrainedScopesAllowed.java
@@ -1,0 +1,19 @@
+package smartthings.dw.oauth.scope;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Container annotation for multiple @FineGrainedScopeAllow. It is implicitly used in Java 8, thanks the @Repeatable
+ * annotation in {@link FineGrainedScopesAllowed}. When using Groovy the container needs to explicitly contains all
+ * the {@link FineGrainedScopeAllowed} entries.
+ */
+@Retention(RUNTIME)
+@Target({TYPE, METHOD})
+public @interface FineGrainedScopesAllowed {
+    FineGrainedScopeAllowed[] value();
+}

--- a/dropwizard-oauth/src/main/java/smartthings/dw/oauth/scope/HttpRequestVarType.java
+++ b/dropwizard-oauth/src/main/java/smartthings/dw/oauth/scope/HttpRequestVarType.java
@@ -1,0 +1,5 @@
+package smartthings.dw.oauth.scope;
+
+public enum HttpRequestVarType {
+    QUERY, PATH, HEADER;
+}

--- a/dropwizard-oauth/src/main/java/smartthings/dw/oauth/scope/ScopesAllowedDynamicFeature.java
+++ b/dropwizard-oauth/src/main/java/smartthings/dw/oauth/scope/ScopesAllowedDynamicFeature.java
@@ -12,16 +12,33 @@ import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.container.DynamicFeature;
 import javax.ws.rs.container.ResourceInfo;
 import javax.ws.rs.core.FeatureContext;
+import javax.ws.rs.core.MultivaluedMap;
 import java.io.IOException;
 import java.security.Principal;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * Note that this code is based on {@link RolesAllowedDynamicFeature} but currently
  * does not intermix intelligently with those annotations. If a method or class uses
  * these annotations as well as the roll annotations both will trigger. Note that a
  * scope annotation on a method will override the annotation on a class.
+ *
+ * Filtering by scope can either be allowed by matching one of {@link ScopesAllowed} or
+ * {@link FineGrainedScopeAllowed}.
+ *
+ * {@link ScopesAllowed} provides matching against an exact string which must be available within
+ * the OAuth scopes.
+ *
+ * {@link FineGrainedScopeAllowed} provides dynamic matching using fine grained scopes format which can
+ * depend on values that are resolved through the request's context parameters.
  */
 public class ScopesAllowedDynamicFeature implements DynamicFeature {
+    // this pattern matches only camel case starting with lower case, so sorry if I am forcing
+    // you to conform, but this makes sense since they are for variables
+    private static final Pattern varNamePattern = Pattern.compile("\\{([a-z]\\w*)\\}");
 
 	@Override
 	public void configure(ResourceInfo resourceInfo, FeatureContext configuration) {
@@ -29,14 +46,18 @@ public class ScopesAllowedDynamicFeature implements DynamicFeature {
 
 		// ScopesAllowed on the method takes precedence over class level annotations
 		ScopesAllowed ra = am.getAnnotation(ScopesAllowed.class);
-		if (ra != null) {
-			configuration.register(new ScopesAllowedRequestFilter(ra.value()));
-			return;
-		}
+		FineGrainedScopesAllowed fgra = am.getAnnotation(FineGrainedScopesAllowed.class);
 
-		ra = resourceInfo.getResourceClass().getAnnotation(ScopesAllowed.class);
-		if (ra != null) {
-			configuration.register(new ScopesAllowedRequestFilter(ra.value()));
+		if (ra == null) {
+            ra = resourceInfo.getResourceClass().getAnnotation(ScopesAllowed.class);
+        }
+
+        if (fgra == null) {
+            fgra = resourceInfo.getResourceClass().getAnnotation(FineGrainedScopesAllowed.class);
+        }
+
+		if ((ra != null) || (fgra != null)) {
+			configuration.register(new ScopesAllowedRequestFilter(ra, fgra));
 		}
 	}
 
@@ -44,27 +65,138 @@ public class ScopesAllowedDynamicFeature implements DynamicFeature {
 	private static class ScopesAllowedRequestFilter implements ContainerRequestFilter {
 
 		private final String[] scopesAllowed;
+		private final FineGrainedScopeAllowed[] fineGrainedScopesAllowed;
 
-		ScopesAllowedRequestFilter(final String[] scopesAllowed) {
-			this.scopesAllowed = (scopesAllowed != null) ? scopesAllowed : new String[]{};
+		ScopesAllowedRequestFilter(final ScopesAllowed scopesAllowed,
+                                   final FineGrainedScopesAllowed fineGrainedScopesAllowed) {
+			if ((scopesAllowed != null) && (scopesAllowed.value() != null)) {
+			    this.scopesAllowed = scopesAllowed.value();
+            } else {
+                this.scopesAllowed = new String[]{};
+            }
+
+            if ((fineGrainedScopesAllowed != null) && (fineGrainedScopesAllowed.value() != null)) {
+			    this.fineGrainedScopesAllowed = fineGrainedScopesAllowed.value();
+            } else {
+			    this.fineGrainedScopesAllowed = new FineGrainedScopeAllowed[]{};
+            }
+
+            verifyFineGrainedScopes();
 		}
 
 		@Override
 		public void filter(final ContainerRequestContext requestContext) throws IOException {
-			if (scopesAllowed.length > 0 && !isAuthenticated(requestContext)) {
-				throw new ForbiddenException(LocalizationMessages.USER_NOT_AUTHORIZED());
-			}
+		    if (isAuthenticated(requestContext)) {
+                Principal principal = requestContext.getSecurityContext().getUserPrincipal();
+                if (principal instanceof ScopeSupport) {
+                    final Collection<String> scopes = Collections.unmodifiableCollection(
+                        ((ScopeSupport) principal).getScopes());
 
-			Principal principal = requestContext.getSecurityContext().getUserPrincipal();
-			if (principal instanceof ScopeSupport) {
-				for (String role : scopesAllowed) {
-					if (((ScopeSupport) principal).getScopes().contains(role)) {
-						return;
-					}
-				}
-			}
+                    for (String allowedScope : scopesAllowed) {
+                        if (scopes.contains(allowedScope)) {
+                            return;
+                        }
+                    }
+
+                    for (FineGrainedScopeAllowed allowedScope : fineGrainedScopesAllowed) {
+                        if (checkFineGrainedScope(scopes, allowedScope, requestContext)) {
+                            return;
+                        }
+                    }
+                }
+            }
+
 			throw new ForbiddenException(LocalizationMessages.USER_NOT_AUTHORIZED());
 		}
+
+		private void verifyFineGrainedScopes() {
+		    for (FineGrainedScopeAllowed scope : fineGrainedScopesAllowed) {
+                Set<String> varNames = Arrays.stream(scope.varInfo()).map(x -> x.name()).collect(Collectors.toSet());
+                Set<String> patternVars = new HashSet<>();
+
+                Matcher m = varNamePattern.matcher(scope.scope());
+                while (m.find()) {
+                    // get match inside {}
+                    patternVars.add(m.group(1));
+                }
+
+                Set<String> intersection = new HashSet<>(varNames);
+                intersection.retainAll(patternVars);
+
+                if ((varNames.size() != patternVars.size()) || (intersection.size() != patternVars.size())) {
+                    throw new IllegalArgumentException("List variables defined in scope pattern do not match variable info");
+                }
+            }
+        }
+
+        private static boolean checkFineGrainedScope(Collection<String> scopes, FineGrainedScopeAllowed scopeAllowed,
+                                              ContainerRequestContext context) {
+		    String contextAwareScope = renderContextFineGrainedScope(scopeAllowed, context);
+
+		    if (contextAwareScope != null) {
+                return fineGrainedScopePartsMatch(scopes, contextAwareScope);
+            }
+
+            return false;
+        }
+
+        private static String renderContextFineGrainedScope(FineGrainedScopeAllowed scopeAllowed, ContainerRequestContext context) {
+            String contextAwareScope = scopeAllowed.scope();
+            for (VarInfo info : scopeAllowed.varInfo()) {
+                String pattern = String.format("{%s}", info.name());
+
+                MultivaluedMap<String, String> contextParams;
+                switch (info.type()) {
+                    case PATH:
+                        contextParams = context.getUriInfo().getPathParameters();
+                        break;
+                    case QUERY:
+                        contextParams = context.getUriInfo().getQueryParameters();
+                        break;
+                    case HEADER:
+                        contextParams = context.getHeaders();
+                        break;
+                    default:
+                        contextParams = null;
+                }
+
+                String value = contextParams.getFirst(info.name());
+
+                if (value == null) {
+                    return null;
+                }
+
+                contextAwareScope = contextAwareScope.replace(pattern, value);
+            }
+
+            return contextAwareScope;
+        }
+
+        private static boolean fineGrainedScopePartsMatch(Collection<String> scopes, String allowedScope) {
+		    String[] allowedScopedParts = allowedScope.split(":");
+		    for (String scope : scopes) {
+                String[] scopeParts = scope.split(":");
+		        boolean matches = true;
+
+		        if (scopeParts.length == allowedScopedParts.length) {
+                    for (int i = 0; i < allowedScopedParts.length; i++) {
+                        if (allowedScopedParts[i].equals("*") || allowedScopedParts[i].equals(scopeParts[i])) {
+                            matches = matches && true;
+                        } else {
+                            matches = false;
+                        }
+                    }
+                } else {
+		            matches = false;
+                }
+
+                if (matches) {
+		            return true;
+                }
+            }
+
+            return false;
+        }
 
 		private static boolean isAuthenticated(final ContainerRequestContext requestContext) {
 			return requestContext.getSecurityContext().getUserPrincipal() != null;

--- a/dropwizard-oauth/src/main/java/smartthings/dw/oauth/scope/VarInfo.java
+++ b/dropwizard-oauth/src/main/java/smartthings/dw/oauth/scope/VarInfo.java
@@ -1,0 +1,6 @@
+package smartthings.dw.oauth.scope;
+
+public @interface VarInfo {
+    HttpRequestVarType type();
+    String name();
+}

--- a/dropwizard-oauth/src/test/groovy/smartthings/dw/oauth/scope/ScopesAllowedDynamicFeatureSpec.groovy
+++ b/dropwizard-oauth/src/test/groovy/smartthings/dw/oauth/scope/ScopesAllowedDynamicFeatureSpec.groovy
@@ -13,8 +13,11 @@ import smartthings.dw.oauth.TokenAuthorizer
 import spock.lang.Specification
 import spock.lang.Unroll
 
+import javax.ws.rs.container.ResourceInfo
+import javax.ws.rs.core.FeatureContext
 import javax.ws.rs.core.MediaType
 import javax.ws.rs.core.Response
+import java.lang.reflect.Method
 
 class ScopesAllowedDynamicFeatureSpec extends Specification {
 
@@ -86,4 +89,182 @@ class ScopesAllowedDynamicFeatureSpec extends Specification {
 		['DEVELOPER'] | ['admin']     | "/methodProtectedWithRoleScope"  || 403
 	}
 
+    @Unroll
+    def 'GET #path with #roles, #scopes, #queryParams, #headerParams returns #status'() {
+        given:
+        User user = new User(null, "charliek", "", "", roles)
+        OAuthToken token = new OAuthToken(Optional.of(user), scopes, "", "TOKEN", [:])
+
+        when:
+        Response response = rule.getJerseyTest().target(path).with { target ->
+            queryParams.each { kv -> target = target.queryParam(kv.key, kv.value) }
+            target
+        }.request(MediaType.APPLICATION_JSON_TYPE)
+        .header("Authorization", "Bearer TOKEN").with { builder ->
+            headerParams.each{ kv -> builder = builder.header(kv.key, kv.value) }
+            builder
+        }.get();
+
+        then:
+        1 * authenticator.authenticate('TOKEN') >> Optional.of(token)
+        0 * _
+
+        and:
+        response.status == status
+
+        where:
+        roles         | scopes                                           | path                        | queryParams              | headerParams             || status
+        ['DEVELOPER'] | ['r:hubs:123456']                                | "/fineGrained/hubId/123456" | [:]                      | [:]                      || 200
+        ['DEVELOPER'] | ['w:hubs:123456']                                | "/fineGrained/hubId/123456" | [:]                      | [:]                      || 200
+        ['DEVELOPER'] | ['superuser']                                    | "/fineGrained/hubId/999999" | [:]                      | [:]                      || 200
+        ['DEVELOPER'] | ['r:hubs:654321']                                | "/fineGrained/hubId/123456" | [:]                      | [:]                      || 403
+        ['USER']      | ['r:hubs:123456']                                | "/fineGrained/hubId/123456" | [:]                      | [:]                      || 403
+        ['DEVELOPER'] | ["r:hubs:1:${UUID.randomUUID()}:a".toString()]   | "/fineGrained/hubId/1"      | [:]                      | [:]                      || 200
+        ['DEVELOPER'] | ["r:hubs:2:${UUID.randomUUID()}:a".toString()]   | "/fineGrained/hubId/1"      | [:]                      | [:]                      || 403
+        ['DEVELOPER'] | ["r:hubs:1:${UUID.randomUUID()}:b".toString()]   | "/fineGrained/hubId/1"      | [:]                      | [:]                      || 403
+        ['DEVELOPER'] | ['r:query:123456']                               | "/fineGrained/queryParam"   | [myQueryParam:'123456']  | [:]                      || 200
+        ['DEVELOPER'] | ['r:query:123456']                               | "/fineGrained/queryParam"   | [myQueryParam:'654321']  | [:]                      || 403
+        ['USER']      | ['r:query:123456']                               | "/fineGrained/queryParam"   | [myQueryParam:'123456']  | [:]                      || 403
+        ['DEVELOPER'] | ["r:query:1:${UUID.randomUUID()}:b".toString()]  |  "/fineGrained/queryParam"  | [myQueryParam:'1']       | [:]                      || 200
+        ['DEVELOPER'] | ["r:query:2:${UUID.randomUUID()}:b".toString()]  |  "/fineGrained/queryParam"  | [myQueryParam:'1']       | [:]                      || 403
+        ['DEVELOPER'] | ["r:query:1:${UUID.randomUUID()}:a".toString()]  |  "/fineGrained/queryParam"  | [myQueryParam:'1']       | [:]                      || 403
+        ['DEVELOPER'] | ['r:header:123456']                              | "/fineGrained/headerParam"  | [:]                      | [myHeaderParam:'123456'] || 200
+        ['DEVELOPER'] | ['r:header:123456']                              | "/fineGrained/headerParam"  | [:]                      | [myHeaderParam:'654321'] || 403
+        ['USER']      | ['r:header:123456']                              | "/fineGrained/headerParam"  | [:]                      | [myHeaderParam:'123456'] || 403
+        ['DEVELOPER'] | ["r:header:1:${UUID.randomUUID()}:c".toString()] | "/fineGrained/headerParam"  | [:]                      | [myHeaderParam:'1']      || 200
+        ['DEVELOPER'] | ["r:header:2:${UUID.randomUUID()}:c".toString()] | "/fineGrained/headerParam"  | [:]                      | [myHeaderParam:'1']      || 403
+        ['DEVELOPER'] | ["r:header:1:${UUID.randomUUID()}:b".toString()] | "/fineGrained/headerParam"  | [:]                      | [myHeaderParam:'1']      || 403
+    }
+
+    def 'principal with null scopes does not throw exception or register filter'() {
+        given:
+        User user = new User(null, "charliek", "", "", ['DEVELOPER'])
+        OAuthToken token = new OAuthToken(Optional.of(user), null, "", "TOKEN", [:])
+
+        when:
+        Response response = rule.getJerseyTest().target("/fineGrained/hubId/123456").
+            request(MediaType.APPLICATION_JSON_TYPE).header("Authorization", "Bearer TOKEN").get()
+
+        then:
+        1 * authenticator.authenticate('TOKEN') >> Optional.of(token)
+        0 * _
+
+        and:
+        response.status != 500
+    }
+
+    def 'token with no principal rejects access'() {
+        given:
+        OAuthToken token = new OAuthToken(null, null, "", "TOKEN", [:])
+
+        when:
+        Response response = rule.getJerseyTest().target("/fineGrained/hubId/123456").
+            request(MediaType.APPLICATION_JSON_TYPE).header("Authorization", "Bearer TOKEN").get()
+
+        then:
+        1 * authenticator.authenticate('TOKEN') >> Optional.of(token)
+        0 * _
+
+        and:
+        response.status != 500
+    }
+
+    @Unroll
+    def 'when invalid fine grained specification #scopeVal - #varName throws exception'() {
+        given:
+        FineGrainedScopesAllowed scopes = Mock()
+        FineGrainedScopeAllowed scope = Mock()
+        VarInfo varInfo = Mock()
+
+        when:
+        new ScopesAllowedDynamicFeature.ScopesAllowedRequestFilter(null, scopes)
+
+        then:
+        thrown(IllegalArgumentException)
+
+        and:
+        2 * scopes.value() >> [scope]
+        1 * scope.varInfo() >> varInfo
+        1 * varInfo.name() >> varName
+        1 * scope.scope() >> scopeVal
+        0 * _
+
+        where:
+        scopeVal        | varName
+        'a:b:c:d:e:f'   | 'a'
+        '{a}:b:c:d:e:f' | 'b'
+    }
+
+    @Unroll
+    def 'When method has #resourceMethod annotations and class has #resourceClass.simpleName annotations then register #doRegister'() {
+        given:
+        ScopesAllowedDynamicFeature feature = new ScopesAllowedDynamicFeature()
+        ResourceInfo resourceInfo = Mock()
+        FeatureContext featureContext = Mock()
+
+        when:
+        feature.configure(resourceInfo, featureContext)
+
+        then:
+        1 * resourceInfo.getResourceMethod() >> NoScope.class.getDeclaredMethod(resourceMethod)
+        numGetClass * resourceInfo.getResourceClass() >> resourceClass
+        if (doRegister) {
+            1 * featureContext.register(_) >> {
+                if([resourceMethod, resourceClass.name].any { it.toLowerCase().contains('fine') }) {
+                    assert it[0].fineGrainedScopesAllowed[0].scope() == '{fine}'
+                }
+
+                if([resourceMethod, resourceClass.name].any { it.toLowerCase().contains('static') }) {
+                    assert it[0].scopesAllowed[0] == 'static'
+                }
+
+
+                null
+            }
+        }
+        0 * _
+
+        where:
+        resourceMethod       | resourceClass      | doRegister | numGetClass | numScopes | numFineScopes
+        'fineAndStaticScope' | FineAndStaticScope | true       | 0           | 1         | 0
+        'fineAndStaticScope' | FineScope          | true       | 0           | 1         | 0
+        'fineAndStaticScope' | NoScope            | true       | 0           | 1         | 0
+        'fineAndStaticScope' | StaticScope        | true       | 0           | 1         | 0
+        'fineScope'          | FineAndStaticScope | true       | 1           | 1         | 0
+        'fineScope'          | FineScope          | true       | 1           | 1         | 0
+        'fineScope'          | NoScope            | true       | 1           | 1         | 0
+        'fineScope'          | StaticScope        | true       | 1           | 1         | 0
+        'noScope'            | FineAndStaticScope | true       | 2           | 0         | 0
+        'noScope'            | FineScope          | true       | 2           | 0         | 0
+        'noScope'            | NoScope            | false      | 2           | 0         | 0
+        'noScope'            | StaticScope        | true       | 2           | 0         | 0
+        'staticScope'        | FineAndStaticScope | true       | 1           | 1         | 0
+        'staticScope'        | FineScope          | true       | 1           | 1         | 0
+        'staticScope'        | NoScope            | true       | 1           | 1         | 0
+        'staticScope'        | StaticScope        | true       | 1           | 1         | 0
+    }
+
+    private static class NoScope {
+        @ScopesAllowed('static')
+        @FineGrainedScopesAllowed([@FineGrainedScopeAllowed(scope='{fine}', varInfo=@VarInfo(name='fine', type=HttpRequestVarType.PATH))])
+        void fineAndStaticScope() {}
+
+        @ScopesAllowed('static')
+        void staticScope() {}
+
+        @FineGrainedScopesAllowed([@FineGrainedScopeAllowed(scope='{fine}', varInfo=@VarInfo(name='fine', type=HttpRequestVarType.PATH))])
+        void fineScope() {}
+
+        void noScope() {}
+    }
+
+    @ScopesAllowed('static')
+    private static class StaticScope {}
+
+    @ScopesAllowed('static')
+    @FineGrainedScopesAllowed([@FineGrainedScopeAllowed(scope='{fine}', varInfo=@VarInfo(name='fine', type=HttpRequestVarType.PATH))])
+    private static class FineAndStaticScope {}
+
+    @FineGrainedScopesAllowed([@FineGrainedScopeAllowed(scope='{fine}', varInfo=@VarInfo(name='fine', type=HttpRequestVarType.PATH))])
+    private static class FineScope {}
 }

--- a/dropwizard-oauth/src/test/groovy/smartthings/dw/oauth/scope/TestScopeResource.groovy
+++ b/dropwizard-oauth/src/test/groovy/smartthings/dw/oauth/scope/TestScopeResource.groovy
@@ -2,7 +2,10 @@ package smartthings.dw.oauth.scope
 
 import javax.annotation.security.RolesAllowed
 import javax.ws.rs.GET
+import javax.ws.rs.HeaderParam
 import javax.ws.rs.Path
+import javax.ws.rs.PathParam
+import javax.ws.rs.QueryParam
 
 @ScopesAllowed("admin")
 @Path("/")
@@ -10,30 +13,64 @@ class TestScopeResource {
 
 	@GET
 	@Path("/classProtected")
-	public String classProtected() {
-		return "OK";
+	String classProtected() {
+		"OK"
 	}
 
 	@GET
 	@Path("/methodProtected")
 	@ScopesAllowed("superuser")
-	public String methodProtected() {
-		return "OK";
+	String methodProtected() {
+        "OK"
 	}
 
 	@GET
 	@Path("/methodProtectedWithRole")
 	@RolesAllowed("DEVELOPER")
-	public String methodProtectedWithRole() {
-		return "OK";
+	String methodProtectedWithRole() {
+        "OK"
 	}
 
 	@GET
 	@Path("/methodProtectedWithRoleScope")
 	@RolesAllowed("DEVELOPER")
 	@ScopesAllowed("superuser")
-	public String methodProtectedWithRoleScope() {
-		return "OK";
+	String methodProtectedWithRoleScope() {
+        "OK"
 	}
 
+    @GET
+    @Path("/fineGrained/hubId/{hubId}")
+    @RolesAllowed("DEVELOPER")
+    @ScopesAllowed("superuser")
+    @FineGrainedScopesAllowed([
+        @FineGrainedScopeAllowed(scope="r:hubs:{hubId}", varInfo=@VarInfo(name="hubId", type=HttpRequestVarType.PATH)),
+        @FineGrainedScopeAllowed(scope="w:hubs:{hubId}", varInfo=@VarInfo(name="hubId", type=HttpRequestVarType.PATH)),
+        @FineGrainedScopeAllowed(scope="r:hubs:{hubId}:*:a", varInfo=@VarInfo(name="hubId", type=HttpRequestVarType.PATH)),
+    ])
+    String protectedHubId(@PathParam("hubId") String hubId) {
+        "OK"
+    }
+
+    @GET
+    @Path("/fineGrained/queryParam")
+    @RolesAllowed("DEVELOPER")
+    @FineGrainedScopesAllowed([
+        @FineGrainedScopeAllowed(scope="r:query:{myQueryParam}", varInfo=@VarInfo(name="myQueryParam", type=HttpRequestVarType.QUERY)),
+        @FineGrainedScopeAllowed(scope="r:query:{myQueryParam}:*:b", varInfo=@VarInfo(name="myQueryParam", type=HttpRequestVarType.QUERY)),
+    ])
+    String protectedQuery(@QueryParam("myQueryParam") String myQueryParam) {
+        "OK"
+    }
+
+    @GET
+    @Path("/fineGrained/headerParam")
+    @RolesAllowed("DEVELOPER")
+    @FineGrainedScopesAllowed([
+        @FineGrainedScopeAllowed(scope="r:header:{myHeaderParam}", varInfo=@VarInfo(name="myHeaderParam", type=HttpRequestVarType.HEADER)),
+        @FineGrainedScopeAllowed(scope="r:header:{myHeaderParam}:*:c", varInfo=@VarInfo(name="myHeaderParam", type=HttpRequestVarType.HEADER))
+    ])
+    String protectedHeader(@HeaderParam("myHeaderParam") String myHeaderParam) {
+        "OK"
+    }
 }


### PR DESCRIPTION
Provide the `@FineGrainedScopeAllowed` annotation to protect resources in
DW against fine grained scopes which can depend on the request context,
i.e. a fine grained scope can be used to match request parameters and
deny the request if the parameter value is not the correct one.

The dynamic matching is not completely free form and expects the scopes
be formatted using the fine grained scope approach to try to mitigate
errors that can lead to security issues.