### PR TITLE
Change method of retrieving @FineGrainedScopeAllowed

### DIFF
--- a/dropwizard-oauth/src/main/java/smartthings/dw/oauth/scope/ScopesAllowedDynamicFeature.java
+++ b/dropwizard-oauth/src/main/java/smartthings/dw/oauth/scope/ScopesAllowedDynamicFeature.java
@@ -46,17 +46,17 @@ public class ScopesAllowedDynamicFeature implements DynamicFeature {
 
 		// ScopesAllowed on the method takes precedence over class level annotations
 		ScopesAllowed ra = am.getAnnotation(ScopesAllowed.class);
-		FineGrainedScopesAllowed fgra = am.getAnnotation(FineGrainedScopesAllowed.class);
+		FineGrainedScopeAllowed[] fgra = am.getAnnotationsByType(FineGrainedScopeAllowed.class);
 
 		if (ra == null) {
             ra = resourceInfo.getResourceClass().getAnnotation(ScopesAllowed.class);
         }
 
-        if (fgra == null) {
-            fgra = resourceInfo.getResourceClass().getAnnotation(FineGrainedScopesAllowed.class);
+        if (fgra.length == 0) {
+            fgra = resourceInfo.getResourceClass().getAnnotationsByType(FineGrainedScopeAllowed.class);
         }
 
-		if ((ra != null) || (fgra != null)) {
+		if ((ra != null) || (fgra.length > 0)) {
 			configuration.register(new ScopesAllowedRequestFilter(ra, fgra));
 		}
 	}
@@ -68,16 +68,17 @@ public class ScopesAllowedDynamicFeature implements DynamicFeature {
 		private final FineGrainedScopeAllowed[] fineGrainedScopesAllowed;
 
 		ScopesAllowedRequestFilter(final ScopesAllowed scopesAllowed,
-                                   final FineGrainedScopesAllowed fineGrainedScopesAllowed) {
+                                   final FineGrainedScopeAllowed[] fineGrainedScopesAllowed) {
 			if ((scopesAllowed != null) && (scopesAllowed.value() != null)) {
 			    this.scopesAllowed = scopesAllowed.value();
             } else {
                 this.scopesAllowed = new String[]{};
             }
 
-            if ((fineGrainedScopesAllowed != null) && (fineGrainedScopesAllowed.value() != null)) {
-			    this.fineGrainedScopesAllowed = fineGrainedScopesAllowed.value();
-            } else {
+            if ((fineGrainedScopesAllowed != null)) {
+			    this.fineGrainedScopesAllowed = fineGrainedScopesAllowed;
+            }
+            else {
 			    this.fineGrainedScopesAllowed = new FineGrainedScopeAllowed[]{};
             }
 

--- a/dropwizard-oauth/src/test/groovy/smartthings/dw/oauth/scope/ScopesAllowedDynamicFeatureSpec.groovy
+++ b/dropwizard-oauth/src/test/groovy/smartthings/dw/oauth/scope/ScopesAllowedDynamicFeatureSpec.groovy
@@ -155,7 +155,7 @@ class ScopesAllowedDynamicFeatureSpec extends Specification {
 
     def 'token with no principal rejects access'() {
         given:
-        OAuthToken token = new OAuthToken(null, null, "", "TOKEN", [:])
+        OAuthToken token = new OAuthToken(Optional.EMPTY, null, "", "TOKEN", [:])
 
         when:
         Response response = rule.getJerseyTest().target("/fineGrained/hubId/123456").
@@ -166,24 +166,23 @@ class ScopesAllowedDynamicFeatureSpec extends Specification {
         0 * _
 
         and:
-        response.status != 500
+        response.status == 403
     }
 
     @Unroll
     def 'when invalid fine grained specification #scopeVal - #varName throws exception'() {
         given:
-        FineGrainedScopesAllowed scopes = Mock()
         FineGrainedScopeAllowed scope = Mock()
         VarInfo varInfo = Mock()
 
         when:
-        new ScopesAllowedDynamicFeature.ScopesAllowedRequestFilter(null, scopes)
+        new ScopesAllowedDynamicFeature.ScopesAllowedRequestFilter(null,
+            (FineGrainedScopeAllowed[])[scope].toArray())
 
         then:
         thrown(IllegalArgumentException)
 
         and:
-        2 * scopes.value() >> [scope]
         1 * scope.varInfo() >> varInfo
         1 * varInfo.name() >> varName
         1 * scope.scope() >> scopeVal


### PR DESCRIPTION
Retrieving the container class for FineGrainedScopeAllowed works only if
annotation is explicitly defined with the container class, or if the
annotation is used more than once. If used only once, fetch the
container annotation will yield nothing.

Using getAnnotationsByType will always return the right amount of
annotations no matter what.