### PR TITLE
Add ability to override Dropwizard Authenticator

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,3 +40,7 @@ subprojects {
 		}
 	}
 }
+
+task wrapper(type: Wrapper) {
+    gradleVersion = '4.3.1'
+}

--- a/dropwizard-oauth/build.gradle
+++ b/dropwizard-oauth/build.gradle
@@ -1,17 +1,20 @@
 dependencies {
-	compile project(':dropwizard-guice')
-	compile project(':dropwizard-logging')
-	compile "io.dropwizard:dropwizard-auth:${dropwizardVersion}"
-	compile "org.asynchttpclient:async-http-client:${asynchttpclientVersion}"
+    compile project(':dropwizard-guice')
+    compile project(':dropwizard-logging')
+    compile "io.dropwizard:dropwizard-auth:${dropwizardVersion}"
+    compile "org.asynchttpclient:async-http-client:${asynchttpclientVersion}"
 
-	testCompile("org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-grizzly2:${jerseyVersion}") {
-		// See http://www.dropwizard.io/0.9.1/docs/manual/auth.html#testing-protected-resources
-		exclude module: 'junit'
-		exclude module: 'javax.servlet-api'
-	}
-	testCompile "io.dropwizard:dropwizard-testing:${dropwizardVersion}"
-	testCompile 'org.spockframework:spock-core:1.0-groovy-2.4'
-	testRuntime 'cglib:cglib-nodep:2.2.2'
-	testRuntime 'org.objenesis:objenesis:1.2'
-	testRuntime 'ch.qos.logback:logback-classic:1.1.2'
+    testCompile("org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-grizzly2:${jerseyVersion}") {
+        // See http://www.dropwizard.io/0.9.1/docs/manual/auth.html#testing-protected-resources
+        exclude module: 'junit'
+        exclude module: 'javax.servlet-api'
+    }
+    testCompile "io.dropwizard:dropwizard-testing:${dropwizardVersion}"
+    testCompile 'org.spockframework:spock-core:1.0-groovy-2.4'
+    testCompile 'com.github.tomakehurst:wiremock-standalone:2.7.1'
+    testCompile project(':dropwizard-async-http-client')
+
+    testRuntime 'cglib:cglib-nodep:2.2.2'
+    testRuntime 'org.objenesis:objenesis:1.2'
+    testRuntime 'ch.qos.logback:logback-classic:1.1.2'
 }

--- a/dropwizard-oauth/src/main/java/smartthings/dw/oauth/AuthModule.java
+++ b/dropwizard-oauth/src/main/java/smartthings/dw/oauth/AuthModule.java
@@ -5,45 +5,48 @@ import com.google.common.cache.CacheBuilder;
 import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import com.google.inject.Singleton;
+import com.google.inject.multibindings.OptionalBinder;
 import io.dropwizard.auth.Authenticator;
 import io.dropwizard.auth.CachingAuthenticator;
 import io.dropwizard.auth.oauth.OAuthCredentialAuthFilter;
-import org.asynchttpclient.AsyncHttpClient;
 import smartthings.dw.guice.AbstractDwModule;
 import smartthings.dw.oauth.scope.ExtendedAuthDynamicFeature;
-
 import java.util.concurrent.TimeUnit;
 
 public class AuthModule extends AbstractDwModule {
 
-	@Override
-	protected void configure() {
-		bind(AuthRegistrationHook.class).in(Scopes.SINGLETON);
-		registerEnvironmentCallback(AuthRegistrationHook.class);
-	}
+    @Override
+    protected void configure() {
+        bind(AuthRegistrationHook.class).in(Scopes.SINGLETON);
+        registerEnvironmentCallback(AuthRegistrationHook.class);
+        OptionalBinder.newOptionalBinder(binder(), OAuthAuthenticator.class)
+            .setDefault().to(SpringSecurityAuthenticator.class);
+    }
 
-	@Provides
-	@Singleton
-	ExtendedAuthDynamicFeature authDynamicFeature(
-			AuthConfiguration config, MetricRegistry registry, AsyncHttpClient client) {
-		Authenticator<String, OAuthToken> authenticator = new SpringSecurityAuthenticator(config, client);
-
-		long cacheMillis = config.getCacheTTL().toMilliseconds();
-		if (cacheMillis > 0) {
-			CacheBuilder<Object, Object> cacheBuilder = CacheBuilder.newBuilder()
-					.maximumSize(100)
-					.expireAfterWrite(cacheMillis, TimeUnit.MILLISECONDS);
-			authenticator = new CachingAuthenticator<>(
-					registry,
-					authenticator,
-					cacheBuilder
-			);
-		}
-		return new ExtendedAuthDynamicFeature(
-				new OAuthCredentialAuthFilter.Builder<OAuthToken>()
-						.setAuthenticator(authenticator)
-						.setAuthorizer(new TokenAuthorizer())
-						.setPrefix("Bearer")
-						.buildAuthFilter());
-	}
+    @Provides
+    @Singleton
+    ExtendedAuthDynamicFeature authDynamicFeature(
+        AuthConfiguration config,
+        MetricRegistry registry,
+        OAuthAuthenticator auth
+    ) {
+        long cacheMillis = config.getCacheTTL().toMilliseconds();
+        Authenticator<String, OAuthToken> authenticator = auth;
+        if (cacheMillis > 0) {
+            CacheBuilder<Object, Object> cacheBuilder = CacheBuilder.newBuilder()
+                    .maximumSize(100)
+                    .expireAfterWrite(cacheMillis, TimeUnit.MILLISECONDS);
+            authenticator = new CachingAuthenticator<>(
+                registry,
+                auth,
+                cacheBuilder
+            );
+        }
+        return new ExtendedAuthDynamicFeature(
+                new OAuthCredentialAuthFilter.Builder<OAuthToken>()
+                        .setAuthenticator(authenticator)
+                        .setAuthorizer(new TokenAuthorizer())
+                        .setPrefix("Bearer")
+                        .buildAuthFilter());
+    }
 }

--- a/dropwizard-oauth/src/main/java/smartthings/dw/oauth/OAuthAuthenticator.java
+++ b/dropwizard-oauth/src/main/java/smartthings/dw/oauth/OAuthAuthenticator.java
@@ -1,0 +1,6 @@
+package smartthings.dw.oauth;
+
+import io.dropwizard.auth.Authenticator;
+
+public interface OAuthAuthenticator extends Authenticator<String, OAuthToken> {
+}

--- a/dropwizard-oauth/src/main/java/smartthings/dw/oauth/OrderedPredicateAuthenticator.java
+++ b/dropwizard-oauth/src/main/java/smartthings/dw/oauth/OrderedPredicateAuthenticator.java
@@ -1,0 +1,78 @@
+package smartthings.dw.oauth;
+
+import com.google.common.collect.ImmutableList;
+import io.dropwizard.auth.AuthenticationException;
+import io.dropwizard.auth.Authenticator;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
+
+public class OrderedPredicateAuthenticator implements OAuthAuthenticator {
+
+    private final List<PredicateAuthenticatorTuple> predicateAuthenticatorTuples;
+
+    public OrderedPredicateAuthenticator(List<PredicateAuthenticatorTuple> tuples) {
+        if (tuples == null || tuples.isEmpty()) {
+            throw new IllegalArgumentException("Authenticator list must not be empty.");
+        }
+        this.predicateAuthenticatorTuples = ImmutableList.copyOf(tuples);
+    }
+
+    @Override
+    public Optional<OAuthToken> authenticate(String credentials) throws AuthenticationException {
+        for (PredicateAuthenticatorTuple predicateValidator : predicateAuthenticatorTuples) {
+            if (predicateValidator.canAuthenticate(credentials)) {
+                return predicateValidator.getAuthenticator().authenticate(credentials);
+            }
+        }
+        return Optional.empty();
+    }
+
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+    public static Builder newBuilder(List<PredicateAuthenticatorTuple> predicateAuthenticatorTuples) {
+        return new Builder(predicateAuthenticatorTuples);
+    }
+
+    public static class Builder {
+        private List<PredicateAuthenticatorTuple> predicateAuthenticatorTuples = new ArrayList<>();
+
+        public Builder() {
+
+        }
+
+        public Builder(List<PredicateAuthenticatorTuple> predicateAuthenticatorTuples) {
+            this.predicateAuthenticatorTuples = predicateAuthenticatorTuples;
+        }
+
+        public List<PredicateAuthenticatorTuple> getPredicateAuthenticatorTuples() {
+            return predicateAuthenticatorTuples;
+        }
+
+        public Builder setPredicateAuthenticatorTuples(List<PredicateAuthenticatorTuple> predicateAuthenticatorTuples) {
+            this.predicateAuthenticatorTuples.addAll(predicateAuthenticatorTuples);
+            return this;
+        }
+
+        public Builder addPredicateAuthenticatorTuple(PredicateAuthenticatorTuple tuple) {
+            this.predicateAuthenticatorTuples.add(tuple);
+            return this;
+        }
+
+        public Builder addPredicateAuthenticatorTuple(
+            Predicate<String> predicate,
+            Authenticator<String, OAuthToken> authenticator
+        ) {
+            this.predicateAuthenticatorTuples.add(new PredicateAuthenticatorTuple(predicate, authenticator));
+            return this;
+        }
+
+        public OrderedPredicateAuthenticator build() {
+            return new OrderedPredicateAuthenticator(predicateAuthenticatorTuples);
+        }
+    }
+}

--- a/dropwizard-oauth/src/main/java/smartthings/dw/oauth/PredicateAuthenticatorTuple.java
+++ b/dropwizard-oauth/src/main/java/smartthings/dw/oauth/PredicateAuthenticatorTuple.java
@@ -1,0 +1,35 @@
+package smartthings.dw.oauth;
+
+import io.dropwizard.auth.Authenticator;
+
+import java.util.function.Predicate;
+
+public class PredicateAuthenticatorTuple {
+
+    private final Predicate<String> predicate;
+    private final Authenticator<String, OAuthToken> authenticator;
+
+    public PredicateAuthenticatorTuple(Predicate<String> predicate, Authenticator<String, OAuthToken> authenticator) {
+        if (predicate == null) {
+            throw new IllegalArgumentException("Authenticator predicate must not be null.");
+        }
+        this.predicate = predicate;
+
+        if (authenticator == null) {
+            throw new IllegalArgumentException("Authenticator must not be null.");
+        }
+        this.authenticator = authenticator;
+    }
+
+    public Predicate<String> getPredicate() {
+        return predicate;
+    }
+
+    public Authenticator<String, OAuthToken> getAuthenticator() {
+        return authenticator;
+    }
+
+    public boolean canAuthenticate(String token) {
+        return predicate.test(token);
+    }
+}

--- a/dropwizard-oauth/src/main/java/smartthings/dw/oauth/SpringSecurityAuthenticator.java
+++ b/dropwizard-oauth/src/main/java/smartthings/dw/oauth/SpringSecurityAuthenticator.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.escape.Escaper;
 import com.google.common.net.UrlEscapers;
 import com.google.common.primitives.Ints;
+import com.google.inject.Singleton;
 import io.dropwizard.auth.AuthenticationException;
 import io.dropwizard.auth.Authenticator;
 import io.dropwizard.jackson.Jackson;
@@ -16,7 +17,8 @@ import smartthings.dw.logging.LoggingContext;
 import javax.inject.Inject;
 import java.util.Optional;
 
-public class SpringSecurityAuthenticator implements Authenticator<String, OAuthToken> {
+@Singleton
+public class SpringSecurityAuthenticator implements OAuthAuthenticator {
 	private static final ObjectMapper MAPPER = Jackson.newObjectMapper();
 	private static final Escaper URL_ESCAPER = UrlEscapers.urlFormParameterEscaper();
 

--- a/dropwizard-oauth/src/test/groovy/smartthings/dw/oauth/AuthModuleOverrideSpec.groovy
+++ b/dropwizard-oauth/src/test/groovy/smartthings/dw/oauth/AuthModuleOverrideSpec.groovy
@@ -1,0 +1,141 @@
+package smartthings.dw.oauth
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration
+import com.github.tomakehurst.wiremock.junit.WireMockRule
+import com.google.inject.Stage
+import com.google.inject.multibindings.OptionalBinder
+import io.dropwizard.Application
+import io.dropwizard.Configuration
+import io.dropwizard.auth.AuthenticationException
+import io.dropwizard.auth.Authenticator
+import io.dropwizard.setup.Environment
+import io.dropwizard.testing.junit.DropwizardAppRule
+import org.asynchttpclient.AsyncHttpClient
+import org.asynchttpclient.DefaultAsyncHttpClient
+import org.asynchttpclient.Response
+import org.junit.ClassRule
+import smartthings.dw.guice.AbstractDwModule
+import smartthings.dw.guice.DwGuice
+import smartthings.dw.oauth.scope.TestScopeResource
+import spock.lang.Shared
+import spock.lang.Specification
+
+class AuthModuleOverrideSpec extends Specification {
+
+    static final int WIRE_MOCK_PORT = 11224
+
+    @ClassRule
+    @Shared
+    WireMockRule authMock = new WireMockRule(WireMockConfiguration.wireMockConfig().port(WIRE_MOCK_PORT))
+
+    @ClassRule
+    @Shared
+    DropwizardAppRule<TestOverrideConfiguration> app = new DropwizardAppRule<>(TestOverrideApplication.class, new TestOverrideConfiguration(
+        auth: new AuthConfiguration(
+            host: "http://localhost:${WIRE_MOCK_PORT}",
+            user: 'user',
+            password: 'password'
+        )
+    ))
+
+    @Shared
+    AsyncHttpClient client = new DefaultAsyncHttpClient()
+
+    @Shared
+    ObjectMapper mapper = new ObjectMapper()
+
+    void setup() {
+        authMock.resetAll()
+    }
+
+    void 'it should validate request authentication'() {
+        given:
+        String token = 'good token'
+
+        when:
+        Response response = client.prepareGet("http://localhost:${app.getLocalPort()}/methodProtected")
+            .addHeader('Authorization', "Bearer ${token}")
+            .execute()
+            .get()
+
+        then:
+        assert response.statusCode == 200
+    }
+
+    void 'it should not validate a request with bad authentication'() {
+        given:
+        String token = 'bad token'
+
+        when:
+        Response response = client.prepareGet("http://localhost:${app.getLocalPort()}/methodProtected")
+            .addHeader('Authorization', "Bearer ${token}")
+            .execute()
+            .get()
+
+        then:
+        assert response.statusCode == 401
+    }
+
+}
+
+class TestOverrideApplication extends Application<TestOverrideConfiguration> {
+    @Override
+    void run(TestOverrideConfiguration configuration, Environment environment) throws Exception {
+        DwGuice.from(Stage.PRODUCTION,
+            new TestOverrideModule(configuration),
+        ).register(environment)
+    }
+}
+
+class TestOverrideModule extends AbstractDwModule {
+
+    TestOverrideConfiguration config
+
+    TestOverrideModule(TestOverrideConfiguration config) {
+        this.config = config
+    }
+
+    @Override
+    protected void configure() {
+        bind(AsyncHttpClient).toInstance(new DefaultAsyncHttpClient())
+        bind(AuthConfiguration).toInstance(config.auth)
+        OptionalBinder.newOptionalBinder(binder(), OAuthAuthenticator.class)
+            .setBinding().toInstance(buildAuthenticator())
+
+        install(new AuthModule())
+        registerResource(TestScopeResource)
+    }
+
+    static OrderedPredicateAuthenticator buildAuthenticator() {
+        return OrderedPredicateAuthenticator.newBuilder()
+            .addPredicateAuthenticatorTuple(
+            { token ->
+                if (token.contains('good')) {
+                    return true
+                }
+                return false
+            },
+            new Authenticator<String, OAuthToken>() {
+                @Override
+                Optional<OAuthToken> authenticate(String token) throws AuthenticationException {
+                    return Optional.of(
+                        new OAuthToken(
+                            Optional.of(
+                                new User(UUID.randomUUID().toString(), 'elmo', 'elmo@smartthings.com', 'elmo', ['ROLE_USER'])
+                            ),
+                            ['superuser'],
+                            UUID.randomUUID().toString(),
+                            token,
+                            [:]
+                        )
+                    )
+                }
+            }
+        ).build()
+    }
+}
+
+class TestOverrideConfiguration extends Configuration {
+    AuthConfiguration auth
+}

--- a/dropwizard-oauth/src/test/groovy/smartthings/dw/oauth/AuthModuleSpec.groovy
+++ b/dropwizard-oauth/src/test/groovy/smartthings/dw/oauth/AuthModuleSpec.groovy
@@ -1,0 +1,107 @@
+package smartthings.dw.oauth
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration
+import com.github.tomakehurst.wiremock.junit.WireMockRule
+import com.google.inject.Stage
+import io.dropwizard.Application
+import io.dropwizard.Configuration
+import io.dropwizard.setup.Environment
+import io.dropwizard.testing.junit.DropwizardAppRule
+import org.asynchttpclient.AsyncHttpClient
+import org.asynchttpclient.DefaultAsyncHttpClient
+import org.asynchttpclient.Response
+import org.junit.ClassRule
+import smartthings.dw.guice.AbstractDwModule
+import smartthings.dw.guice.DwGuice
+import smartthings.dw.oauth.scope.TestScopeResource
+import spock.lang.Shared
+import spock.lang.Specification
+import static com.github.tomakehurst.wiremock.client.WireMock.*
+
+class AuthModuleSpec extends Specification {
+
+    static final int WIRE_MOCK_PORT = 11224
+
+    @ClassRule
+    @Shared
+    WireMockRule authMock = new WireMockRule(WireMockConfiguration.wireMockConfig().port(WIRE_MOCK_PORT))
+
+    @ClassRule
+    @Shared
+    DropwizardAppRule<TestConfiguration> app = new DropwizardAppRule<>(TestApplication.class, new TestConfiguration(
+        auth: new AuthConfiguration(
+            host: "http://localhost:${WIRE_MOCK_PORT}",
+            user: 'user',
+            password: 'password'
+        )
+    ))
+
+    @Shared
+    AsyncHttpClient client = new DefaultAsyncHttpClient()
+
+    @Shared
+    ObjectMapper mapper = new ObjectMapper()
+
+    void setup() {
+        authMock.resetAll()
+    }
+
+    void 'it should validate request authentication'() {
+        given:
+        String token = UUID.randomUUID().toString()
+        AuthResponse authResponse = new AuthResponse(
+            userName: 'elmo',
+            scopes: ['superuser'],
+            uuid: UUID.randomUUID().toString(),
+            clientId: UUID.randomUUID().toString()
+        )
+        authMock
+            .stubFor(post(urlEqualTo("/oauth/check_token"))
+            .withRequestBody(containing(token))
+            .willReturn(aResponse().withStatus(200).withBody(mapper.writeValueAsBytes(authResponse)))
+        )
+
+        when:
+        Response response = client.prepareGet("http://localhost:${app.getLocalPort()}/methodProtected")
+            .addHeader('Authorization', "Bearer ${token}")
+            .execute()
+            .get()
+
+        then:
+        authMock.verify(postRequestedFor(urlEqualTo('/oauth/check_token')))
+
+        assert response.statusCode == 200
+    }
+
+}
+
+class TestApplication extends Application<TestConfiguration> {
+    @Override
+    void run(TestConfiguration configuration, Environment environment) throws Exception {
+        DwGuice.from(Stage.PRODUCTION,
+            new TestModule(configuration),
+        ).register(environment)
+    }
+}
+
+class TestModule extends AbstractDwModule {
+
+    TestConfiguration config
+
+    TestModule(TestConfiguration config) {
+        this.config = config
+    }
+
+    @Override
+    protected void configure() {
+        bind(AsyncHttpClient).toInstance(new DefaultAsyncHttpClient())
+        bind(AuthConfiguration).toInstance(config.auth)
+        install(new AuthModule())
+        registerResource(TestScopeResource)
+    }
+}
+
+class TestConfiguration extends Configuration {
+    AuthConfiguration auth
+}

--- a/dropwizard-oauth/src/test/groovy/smartthings/dw/oauth/scope/TestScopeResource.groovy
+++ b/dropwizard-oauth/src/test/groovy/smartthings/dw/oauth/scope/TestScopeResource.groovy
@@ -1,5 +1,7 @@
 package smartthings.dw.oauth.scope
 
+import smartthings.dw.guice.WebResource
+
 import javax.annotation.security.RolesAllowed
 import javax.ws.rs.GET
 import javax.ws.rs.HeaderParam
@@ -9,7 +11,7 @@ import javax.ws.rs.QueryParam
 
 @ScopesAllowed("admin")
 @Path("/")
-class TestScopeResource {
+class TestScopeResource implements WebResource {
 
 	@GET
 	@Path("/classProtected")

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Jan 12 16:16:53 PST 2017
+#Thu Dec 07 09:30:07 CST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.3.1-bin.zip


### PR DESCRIPTION
Adds:
1) Ability to override the SpringSecurityAuthenticator.
2) Provides an alternate `OrderedPredicateAuthenticator` Authenticator that supports a chain of Authenticators.