### PR TITLE
Set default cassandra health check query as idempotent

### DIFF
--- a/dropwizard-cassandra/src/main/java/smartthings/dw/cassandra/CassandraConfiguration.java
+++ b/dropwizard-cassandra/src/main/java/smartthings/dw/cassandra/CassandraConfiguration.java
@@ -20,8 +20,11 @@ import java.security.SecureRandom;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+@ValidCassandraConfiguration
 public class CassandraConfiguration {
 	private final static Logger LOG = LoggerFactory.getLogger(CassandraConfiguration.class);
+
+	protected final static String  DEFAULT_VALIDATION_QUERY = "SELECT * FROM system.schema_keyspaces";
 
 	private String[] cipherSuites = new String[]{"TLS_RSA_WITH_AES_128_CBC_SHA", "TLS_RSA_WITH_AES_256_CBC_SHA"};
 
@@ -34,8 +37,9 @@ public class CassandraConfiguration {
 	@NotEmpty
 	private String keyspace;
 
-	@NotEmpty
-	private String validationQuery = "SELECT * FROM system.schema_keyspaces";
+	private String validationQuery;
+
+    protected Boolean validationQueryIdempotence;
 
 	private String migrationFile = "/migrations/cql.changelog";
 	private Boolean autoMigrate = false;
@@ -107,8 +111,23 @@ public class CassandraConfiguration {
 	}
 
 	public String getValidationQuery() {
+	    if (validationQuery == null) {
+	        return DEFAULT_VALIDATION_QUERY;
+        }
 		return validationQuery;
 	}
+
+	public boolean getValidationQueryIdempotence() {
+	    if (DEFAULT_VALIDATION_QUERY.equals(getValidationQuery())) {
+	        return true;
+        }
+
+        if (validationQueryIdempotence != null) {
+            return validationQueryIdempotence;
+        }
+
+        return false;
+    }
 
 	public void setValidationQuery(String validationQuery) {
 		this.validationQuery = validationQuery;

--- a/dropwizard-cassandra/src/main/java/smartthings/dw/cassandra/CassandraConfigurationValidator.java
+++ b/dropwizard-cassandra/src/main/java/smartthings/dw/cassandra/CassandraConfigurationValidator.java
@@ -1,0 +1,27 @@
+package smartthings.dw.cassandra;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class CassandraConfigurationValidator implements ConstraintValidator<ValidCassandraConfiguration, CassandraConfiguration> {
+    @Override
+    public void initialize(ValidCassandraConfiguration annotation) {
+    }
+
+    @Override
+    public boolean isValid(CassandraConfiguration config, ConstraintValidatorContext context) {
+        boolean valid = true;
+        if (!config.DEFAULT_VALIDATION_QUERY.equals(config.getValidationQuery())) {
+            if (config.validationQueryIdempotence == null) {
+                context.buildConstraintViolationWithTemplate("must be defined "+
+                    "when validationQuery is defined ")
+                    .addPropertyNode("validationQueryIdempotence")
+                    .addBeanNode()
+                    .addConstraintViolation();
+                valid = false;
+            }
+        }
+
+        return valid;
+    }
+}

--- a/dropwizard-cassandra/src/main/java/smartthings/dw/cassandra/ValidCassandraConfiguration.java
+++ b/dropwizard-cassandra/src/main/java/smartthings/dw/cassandra/ValidCassandraConfiguration.java
@@ -1,0 +1,20 @@
+package smartthings.dw.cassandra;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Target(TYPE)
+@Retention(RUNTIME)
+@Constraint(validatedBy = {CassandraConfigurationValidator.class})
+public @interface ValidCassandraConfiguration {
+    String message() default "CassandraConfiguration fails ValidCassandraConfiguration constraint";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/dropwizard-cassandra/src/test/groovy/smartthings/dw/cassandra/CassandraConfigurationSpec.groovy
+++ b/dropwizard-cassandra/src/test/groovy/smartthings/dw/cassandra/CassandraConfigurationSpec.groovy
@@ -1,0 +1,38 @@
+package smartthings.dw.cassandra
+
+import io.dropwizard.configuration.ConfigurationValidationException
+import io.dropwizard.configuration.YamlConfigurationFactory
+import io.dropwizard.jackson.Jackson
+import io.dropwizard.validation.BaseValidator
+import spock.lang.Specification
+
+import javax.validation.Validator
+
+
+class CassandraConfigurationSpec extends Specification {
+    static final Validator validator = BaseValidator.newValidator();
+    static final YamlConfigurationFactory factory = new YamlConfigurationFactory<>(
+        CassandraConfiguration.class, validator, Jackson.newObjectMapper(), "dw");
+
+    def 'configuration is deserialized if custom validtion query does specify idempotence'() {
+        given:
+        File f = new File(this.class.classLoader.getResource('valid-cassandra-config.yml').toURI())
+
+        when:
+        factory.build(f)
+
+        then:
+        noExceptionThrown()
+    }
+
+    def 'configuration fails validation if custom validtion query does not specify idempotence'() {
+        given:
+        File f = new File(this.class.classLoader.getResource('invalid-cassandra-config.yml').toURI())
+
+        when:
+        factory.build(f)
+
+        then:
+        thrown(ConfigurationValidationException)
+    }
+}

--- a/dropwizard-cassandra/src/test/resources/invalid-cassandra-config.yml
+++ b/dropwizard-cassandra/src/test/resources/invalid-cassandra-config.yml
@@ -1,0 +1,3 @@
+---
+keyspace: keyspace
+validationQuery: custom query

--- a/dropwizard-cassandra/src/test/resources/valid-cassandra-config.yml
+++ b/dropwizard-cassandra/src/test/resources/valid-cassandra-config.yml
@@ -1,0 +1,4 @@
+---
+keyspace: keyspace
+validationQuery: custom query
+validationQueryIdempotence: false


### PR DESCRIPTION
The default health check query is not set as idempotent, which can might
end up marking an instance as unhealthy in situations where they should
still be able to function. This change will set it to idempotent to fix
those situations.

Also, allow setting the health check query idempotence in the
configuration when a custom query is used. If a custom query is used and
idempotence is not specified, fail CassandraConfiguration validation
checks.