### PR TITLE
Reuse prepared statement to avoid noise in the logs

### DIFF
--- a/dropwizard-cassandra/src/test/groovy/smartthings/dw/cassandra/CassandraModuleSpec.groovy
+++ b/dropwizard-cassandra/src/test/groovy/smartthings/dw/cassandra/CassandraModuleSpec.groovy
@@ -2,6 +2,7 @@ package smartthings.dw.cassandra
 
 import com.codahale.metrics.health.HealthCheck
 import com.datastax.driver.core.Cluster
+import com.datastax.driver.core.PreparedStatement
 import com.datastax.driver.core.Session
 import com.datastax.driver.mapping.MappingManager
 import com.google.inject.Guice
@@ -11,7 +12,11 @@ import io.dropwizard.lifecycle.Managed
 import smartthings.dw.guice.AbstractDwModule
 import spock.lang.Specification
 
+
 class CassandraModuleSpec extends Specification {
+
+    final static String validationQuery = 'validation query'
+    final static boolean validationQueryIdempotence = true
 
     CassandraConfiguration config
     Session session
@@ -36,6 +41,8 @@ class CassandraModuleSpec extends Specification {
         cluster = Mock(Cluster)
         config.buildSession() >> session
         config.getShutdownTimeoutInMillis() >> 30000
+        config.getValidationQuery() >> validationQuery
+        config.getValidationQueryIdempotence() >> validationQueryIdempotence
         session.getCluster() >> cluster
     }
 


### PR DESCRIPTION
Reduce these kind of warnings in the logs:
```
WARN   [11:17:08.879] [cluster2-worker-9] c.d.d.c.Cluster -  Re-preparing already prepared query is generally an anti-pattern and will likely affect performance. Consider preparing the statement only once. Query='SELECT * FROM system.schema_keyspaces'
```