### PR TITLE
NOV-1385 Remove mobile scoped token support from Marconi

### DIFF
--- a/dropwizard-oauth/src/main/java/smartthings/dw/oauth/scope/ExtendedAuthDynamicFeature.java
+++ b/dropwizard-oauth/src/main/java/smartthings/dw/oauth/scope/ExtendedAuthDynamicFeature.java
@@ -36,7 +36,8 @@ public class ExtendedAuthDynamicFeature implements DynamicFeature {
 	}
 
 	private static List<Class<? extends Annotation>> AUTH_ANNOTATIONS = ImmutableList.of(
-			RolesAllowed.class, DenyAll.class, PermitAll.class, ScopesAllowed.class);
+			RolesAllowed.class, DenyAll.class, PermitAll.class, ScopesAllowed.class,
+        FineGrainedScopeAllowed.class, FineGrainedScopesAllowed.class);
 
 	private boolean hasMethodAnnotation(ResourceInfo resourceInfo) {
 		AnnotatedMethod am = new AnnotatedMethod(resourceInfo.getResourceMethod());

--- a/dropwizard-oauth/src/test/groovy/smartthings/dw/oauth/scope/ScopesAllowedDynamicFeatureSpec.groovy
+++ b/dropwizard-oauth/src/test/groovy/smartthings/dw/oauth/scope/ScopesAllowedDynamicFeatureSpec.groovy
@@ -8,8 +8,8 @@ import org.glassfish.jersey.server.filter.RolesAllowedDynamicFeature
 import org.glassfish.jersey.test.grizzly.GrizzlyWebTestContainerFactory
 import org.junit.Rule
 import smartthings.dw.oauth.OAuthToken
-import smartthings.dw.oauth.User
 import smartthings.dw.oauth.TokenAuthorizer
+import smartthings.dw.oauth.User
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -17,7 +17,6 @@ import javax.ws.rs.container.ResourceInfo
 import javax.ws.rs.core.FeatureContext
 import javax.ws.rs.core.MediaType
 import javax.ws.rs.core.Response
-import java.lang.reflect.Method
 
 class ScopesAllowedDynamicFeatureSpec extends Specification {
 

--- a/dropwizard-oauth/src/test/groovy/smartthings/dw/oauth/scope/TestFineGrainedScopeResource.groovy
+++ b/dropwizard-oauth/src/test/groovy/smartthings/dw/oauth/scope/TestFineGrainedScopeResource.groovy
@@ -1,0 +1,20 @@
+package smartthings.dw.oauth.scope
+
+import smartthings.dw.guice.WebResource
+
+import javax.ws.rs.GET
+import javax.ws.rs.Path
+import javax.ws.rs.PathParam
+
+@Path("/")
+class TestFineGrainedScopeResource implements WebResource {
+
+    @GET
+    @Path("/fineGrained/standalone/{param}")
+    @FineGrainedScopesAllowed([
+        @FineGrainedScopeAllowed(scope="r:path:{param}", varInfo=@VarInfo(name="param", type=HttpRequestVarType.PATH)),
+    ])
+    String protectedPath(@PathParam("param") String myPathParam) {
+        "OK"
+    }
+}

--- a/dropwizard-oauth/src/test/groovy/smartthings/dw/oauth/scope/TestFineGrainedScopeResourceSpec.groovy
+++ b/dropwizard-oauth/src/test/groovy/smartthings/dw/oauth/scope/TestFineGrainedScopeResourceSpec.groovy
@@ -1,0 +1,57 @@
+package smartthings.dw.oauth.scope
+
+import io.dropwizard.auth.AuthValueFactoryProvider
+import io.dropwizard.auth.Authenticator
+import io.dropwizard.auth.oauth.OAuthCredentialAuthFilter
+import io.dropwizard.testing.junit.ResourceTestRule
+import org.glassfish.jersey.server.filter.RolesAllowedDynamicFeature
+import org.glassfish.jersey.test.grizzly.GrizzlyWebTestContainerFactory
+import org.junit.Rule
+import smartthings.dw.oauth.OAuthToken
+import smartthings.dw.oauth.TokenAuthorizer
+import smartthings.dw.oauth.User
+import spock.lang.Specification
+
+import javax.ws.rs.core.MediaType
+import javax.ws.rs.core.Response
+
+class TestFineGrainedScopeResourceSpec extends Specification {
+
+    Authenticator<String, OAuthToken> authenticator = Mock()
+
+    @Rule
+    public ResourceTestRule rule = ResourceTestRule
+        .builder()
+        .setTestContainerFactory(new GrizzlyWebTestContainerFactory())
+        .addProvider(new ExtendedAuthDynamicFeature(new OAuthCredentialAuthFilter.Builder<OAuthToken>()
+        .setAuthenticator(authenticator)
+        .setAuthorizer(new TokenAuthorizer())
+        .setPrefix("Bearer")
+        .buildAuthFilter()))
+        .addProvider(ScopesAllowedDynamicFeature.class)
+        .addProvider(RolesAllowedDynamicFeature.class)
+        .addProvider(new AuthValueFactoryProvider.Binder<OAuthToken>(OAuthToken.class))
+        .addResource(new TestFineGrainedScopeResource())
+        .build()
+
+
+    def 'should allow standalone FineGrainedScope annotations'() {
+        given:
+        User user = new User(null, "user", "", "", [""])
+        OAuthToken token = new OAuthToken(Optional.of(user), ['r:path:param'], "", "TOKEN", [:])
+
+        when:
+        Response response = rule.getJerseyTest().target("/fineGrained/standalone/param")
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .header("Authorization", "Bearer TOKEN")
+            .get()
+
+        then:
+        1 * authenticator.authenticate('TOKEN') >> Optional.of(token)
+        0 * _
+
+        and:
+        response.status == 200
+    }
+
+}


### PR DESCRIPTION
It's now possible to have a standalone `@FineGrainedScope(s)Allowed` annotation.