### PR TITLE
Make Auth Response forwarding to client configurable

### DIFF
--- a/dropwizard-common-classes/build.gradle
+++ b/dropwizard-common-classes/build.gradle
@@ -1,0 +1,3 @@
+dependencies {
+    compile "io.dropwizard:dropwizard-core:${dropwizardVersion}"
+}

--- a/dropwizard-common-classes/src/main/java/smartthings/dw/exceptions/TransparentResponseStatusException.java
+++ b/dropwizard-common-classes/src/main/java/smartthings/dw/exceptions/TransparentResponseStatusException.java
@@ -1,0 +1,13 @@
+package smartthings.dw.exceptions;
+
+import javax.ws.rs.WebApplicationException;
+
+public class TransparentResponseStatusException extends WebApplicationException {
+    public TransparentResponseStatusException(final int status) {
+        super(status);
+    }
+
+    public int getStatus() {
+        return getResponse().getStatus();
+    }
+}

--- a/dropwizard-oauth/build.gradle
+++ b/dropwizard-oauth/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+    compile project(':dropwizard-common-classes')
     compile project(':dropwizard-guice')
     compile project(':dropwizard-logging')
     compile "io.dropwizard:dropwizard-auth:${dropwizardVersion}"

--- a/dropwizard-oauth/src/main/java/smartthings/dw/oauth/AuthConfiguration.java
+++ b/dropwizard-oauth/src/main/java/smartthings/dw/oauth/AuthConfiguration.java
@@ -1,9 +1,12 @@
 package smartthings.dw.oauth;
 
+import com.google.common.collect.ImmutableSet;
 import io.dropwizard.util.Duration;
 import org.hibernate.validator.constraints.NotEmpty;
 
 import javax.validation.constraints.NotNull;
+import java.util.HashSet;
+import java.util.Set;
 
 public class AuthConfiguration {
 
@@ -24,6 +27,9 @@ public class AuthConfiguration {
 
 	@NotNull
 	private Boolean enabled = true;
+
+	@NotNull
+	private Set<Integer> transparentServerStatusCodes = new HashSet<>();
 
 	public String getHost() {
 		return host;
@@ -72,4 +78,12 @@ public class AuthConfiguration {
 	public void setEnabled(Boolean enabled) {
 		this.enabled = enabled;
 	}
+
+	public void setTransparentServerStatusCodes(Set<Integer> transparentServerStatusCodes) {
+	    this.transparentServerStatusCodes = ImmutableSet.copyOf(transparentServerStatusCodes);
+    }
+
+	public Set<Integer> getTransparentServerStatusCodes() {
+	    return transparentServerStatusCodes;
+    }
 }

--- a/dropwizard-oauth/src/main/java/smartthings/dw/oauth/SpringSecurityAuthenticator.java
+++ b/dropwizard-oauth/src/main/java/smartthings/dw/oauth/SpringSecurityAuthenticator.java
@@ -11,6 +11,7 @@ import org.asynchttpclient.AsyncHttpClient;
 import org.asynchttpclient.DefaultAsyncHttpClient;
 import org.asynchttpclient.Realm;
 import org.asynchttpclient.Response;
+import smartthings.dw.exceptions.TransparentResponseStatusException;
 import smartthings.dw.logging.LoggingContext;
 
 import javax.inject.Inject;
@@ -65,8 +66,8 @@ public class SpringSecurityAuthenticator implements OAuthAuthenticator {
 
         if (code >= 400 && code < 500) {
             return Optional.empty();
-        } else if (code == 520) {
-            throw new SlowResponseException();
+        } else if (config.getTransparentServerStatusCodes().contains(code)) {
+            throw new TransparentResponseStatusException(code);
         }
 
         throw new AuthenticationException(String.format("Invalid status code found %d", code));

--- a/dropwizard-oauth/src/test/groovy/smartthings/dw/oauth/AuthModuleSpec.groovy
+++ b/dropwizard-oauth/src/test/groovy/smartthings/dw/oauth/AuthModuleSpec.groovy
@@ -23,7 +23,9 @@ import static com.github.tomakehurst.wiremock.client.WireMock.*
 
 class AuthModuleSpec extends Specification {
 
+    @Shared
     static final int WIRE_MOCK_PORT = 11224
+    static final Set<Integer> transparentServerStatusCodes = [520, 521] as Set
 
     @ClassRule
     @Shared
@@ -35,7 +37,8 @@ class AuthModuleSpec extends Specification {
         auth: new AuthConfiguration(
             host: "http://localhost:${WIRE_MOCK_PORT}",
             user: 'user',
-            password: 'password'
+            password: 'password',
+            transparentServerStatusCodes: transparentServerStatusCodes
         )
     ))
 
@@ -77,7 +80,7 @@ class AuthModuleSpec extends Specification {
     }
 
     @Unroll
-    void 'when the oauth reponse is #oauthStatus the request response is #requestStatus'() {
+    void 'when the oauth response is #oauthStatus the request response is #requestStatus'() {
         given:
         String token = UUID.randomUUID().toString()
         authMock
@@ -103,7 +106,12 @@ class AuthModuleSpec extends Specification {
         401         | 401
         499         | 401
         500         | 500
+        501         | 500
+        501         | 500
+        519         | 500
         520         | 520
+        521         | 521
+        522         | 500
         666         | 500
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -8,6 +8,7 @@ include 'dropwizard-protobuf'
 include 'dropwizard-async-http-client'
 include 'dropwizard-timer'
 include 'dropwizard-success-meter'
+include 'dropwizard-common-classes'
 
 rootProject.name = 'dropwizard-common'
 include 'dropwizard-zipkin'


### PR DESCRIPTION
Allow specifying the status code for auth server responses that should be
forwarded to original requesting client.