### PR TITLE
EDGE-9 Update async-http-client to latest version

### DIFF
--- a/dropwizard-async-http-client/src/main/java/smartthings/dw/asynchttpclient/CorrelationIdFilter.java
+++ b/dropwizard-async-http-client/src/main/java/smartthings/dw/asynchttpclient/CorrelationIdFilter.java
@@ -1,7 +1,9 @@
 package smartthings.dw.asynchttpclient;
 
 import io.netty.handler.codec.http.HttpHeaders;
-import org.asynchttpclient.*;
+import org.asynchttpclient.AsyncHandler;
+import org.asynchttpclient.HttpResponseBodyPart;
+import org.asynchttpclient.HttpResponseStatus;
 import org.asynchttpclient.filter.FilterContext;
 import org.asynchttpclient.filter.FilterException;
 import org.asynchttpclient.filter.RequestFilter;
@@ -55,7 +57,7 @@ public class CorrelationIdFilter implements RequestFilter {
 					}
 
 					@Override
-					public State onHeadersReceived(HttpResponseHeaders headers) throws Exception {
+					public State onHeadersReceived(HttpHeaders headers) throws Exception {
 						try {
 							mdc.forEach(MDC::put);
 							return asyncHandler.onHeadersReceived(headers);

--- a/dropwizard-async-http-client/src/test/groovy/smartthings/dw/asynchttpclient/AsyncHttpClientModuleSpec.groovy
+++ b/dropwizard-async-http-client/src/test/groovy/smartthings/dw/asynchttpclient/AsyncHttpClientModuleSpec.groovy
@@ -34,7 +34,7 @@ class AsyncHttpClientModuleSpec extends spock.lang.Specification {
 		client.config.requestFilters.size() == 1
 		client.config.requestFilters[0] instanceof CorrelationIdFilter
 		client.config.connectTimeout == 5000
-		client.config.acceptAnyCertificate == false
+		client.config.useInsecureTrustManager == false
 
 		and: 'default overrides are used'
 		client.config.requestTimeout == 5000
@@ -45,7 +45,7 @@ class AsyncHttpClientModuleSpec extends spock.lang.Specification {
 		given:
 		def overrides = [
 			connectTimeout: 100,
-			acceptAnyCertificate: true,
+			useInsecureTrustManager: true,
 			readTimeout: 1000
 		]
 		Injector injector = Guice.createInjector(new AsyncHttpClientModule(new AsyncHttpClientConfig(properties: overrides)))

--- a/dropwizard-async-http-client/src/test/groovy/smartthings/dw/asynchttpclient/CorrelationIdFilterSpec.groovy
+++ b/dropwizard-async-http-client/src/test/groovy/smartthings/dw/asynchttpclient/CorrelationIdFilterSpec.groovy
@@ -3,7 +3,6 @@ package smartthings.dw.asynchttpclient
 import io.netty.handler.codec.http.HttpHeaders
 import org.asynchttpclient.AsyncHandler
 import org.asynchttpclient.HttpResponseBodyPart
-import org.asynchttpclient.HttpResponseHeaders
 import org.asynchttpclient.HttpResponseStatus
 import org.asynchttpclient.Request
 import org.asynchttpclient.filter.FilterContext
@@ -52,9 +51,9 @@ class CorrelationIdFilterSpec extends Specification {
 			}
 
 			@Override
-			AsyncHandler.State onHeadersReceived(HttpResponseHeaders headers) throws Exception {
+			AsyncHandler.State onHeadersReceived(HttpHeaders headers) throws Exception {
 				callResults.onHeaders = MDC.get(FOO)
-				return AsyncHandler.State.UPGRADE
+				return AsyncHandler.State.CONTINUE
 			}
 
 			@Override
@@ -129,7 +128,7 @@ class CorrelationIdFilterSpec extends Specification {
 		callResults.onHeaders == 'bar'
 		fooBefore == null
 		fooAfter == null
-		result == AsyncHandler.State.UPGRADE
+		result == AsyncHandler.State.CONTINUE
 
 		when:
 		Thread.start {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 dropwizardVersion=1.2.2
 # Make sure to update jersey version with dropwizard
 jerseyVersion=2.25.1
-asynchttpclientVersion=2.0.32
+asynchttpclientVersion=2.4.5
 zipkinAwsVersion=0.2.1
 awsSdkVersion=1.11.49
 stBraveVersion=0.1.14


### PR DESCRIPTION
Changes in async-http-client are:
* Netty version upgrade
* `acceptAnyCertificate` was renamed `useInsecureTrustManager`