### PR TITLE
Add channel object pool to reuse channels between threads

### DIFF
--- a/dropwizard-rabbitmq/build.gradle
+++ b/dropwizard-rabbitmq/build.gradle
@@ -2,6 +2,7 @@ dependencies {
     compile project(':dropwizard-guice')
 
     compile 'com.rabbitmq:amqp-client:5.3.0'
+    compile group: 'org.apache.commons', name: 'commons-pool2', version: '2.6.0'
 
     testCompile 'org.spockframework:spock-core:1.1-groovy-2.4'
 

--- a/dropwizard-rabbitmq/src/main/java/smartthings/dw/rabbitmq/connection/ChannelPoolFactory.java
+++ b/dropwizard-rabbitmq/src/main/java/smartthings/dw/rabbitmq/connection/ChannelPoolFactory.java
@@ -1,0 +1,41 @@
+package smartthings.dw.rabbitmq.connection;
+
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.Connection;
+import org.apache.commons.pool2.PooledObject;
+import org.apache.commons.pool2.PooledObjectFactory;
+import org.apache.commons.pool2.impl.DefaultPooledObject;
+
+public class ChannelPoolFactory implements PooledObjectFactory<Channel> {
+
+    private final Connection connection;
+
+    public ChannelPoolFactory(Connection connection) {
+        this.connection = connection;
+    }
+
+    @Override
+    public PooledObject<Channel> makeObject() throws Exception {
+        return new DefaultPooledObject<>(connection.createChannel());
+    }
+
+    @Override
+    public void destroyObject(PooledObject<Channel> pooledChannel) throws Exception {
+        pooledChannel.getObject().close();
+    }
+
+    @Override
+    public boolean validateObject(PooledObject<Channel> pooledChannel) {
+        return pooledChannel.getObject().isOpen();
+    }
+
+    @Override
+    public void activateObject(PooledObject<Channel> pooledChannel) throws Exception {
+        return;
+    }
+
+    @Override
+    public void passivateObject(PooledObject<Channel> pooledChannel) throws Exception {
+        return;
+    }
+}

--- a/dropwizard-rabbitmq/src/test/groovy/smartthings/dw/rabbitmq/ManagedRabbitMQConnectionSpec.groovy
+++ b/dropwizard-rabbitmq/src/test/groovy/smartthings/dw/rabbitmq/ManagedRabbitMQConnectionSpec.groovy
@@ -101,4 +101,21 @@ class ManagedRabbitMQConnectionSpec extends Specification {
         1 * connection.abort(shutdownTimeout)
         0 * _
     }
+
+    def "Should borrow channel from pool"() {
+        given: "a mock channel"
+        Channel channel = Mock(Channel)
+
+        when: "getting a channel the first time"
+        Channel chan = managedConnection.getChannel()
+
+        then: "it should create a channel"
+        1 * connection.createChannel() >> channel
+
+        when: "returning the channel and borrowing again"
+        managedConnection.returnChannel(channel)
+
+        then: "it should not create another channel"
+        0 * connection.createChannel()
+    }
 }


### PR DESCRIPTION
This adds a channel object pool for managed RabbitMQ connections so we can reuse channels between threads and guarantee thread safety. 