### PR TITLE
HCS-747 ASA-151 Fixing bug in fine grained scope checking

### DIFF
--- a/dropwizard-oauth/src/main/java/smartthings/dw/oauth/scope/ScopesAllowedDynamicFeature.java
+++ b/dropwizard-oauth/src/main/java/smartthings/dw/oauth/scope/ScopesAllowedDynamicFeature.java
@@ -181,7 +181,7 @@ public class ScopesAllowedDynamicFeature implements DynamicFeature {
 
 		        if (scopeParts.length == allowedScopedParts.length) {
                     for (int i = 0; i < allowedScopedParts.length; i++) {
-                        if (allowedScopedParts[i].equals("*") || allowedScopedParts[i].equals(scopeParts[i])) {
+                        if (scopeParts[i].equals("*") || allowedScopedParts[i].equals("*") || allowedScopedParts[i].equals(scopeParts[i])) {
                             matches = matches && true;
                         } else {
                             matches = false;

--- a/dropwizard-oauth/src/test/groovy/smartthings/dw/oauth/scope/ScopesAllowedDynamicFeatureSpec.groovy
+++ b/dropwizard-oauth/src/test/groovy/smartthings/dw/oauth/scope/ScopesAllowedDynamicFeatureSpec.groovy
@@ -242,6 +242,23 @@ class ScopesAllowedDynamicFeatureSpec extends Specification {
         'staticScope'        | StaticScope        | true       | 1           | 1         | 0
     }
 
+    @Unroll
+    def 'fineGrainedScopePartsMatch should work correctly with *s'() {
+        when:
+        boolean isMatch = ScopesAllowedDynamicFeature.ScopesAllowedRequestFilter.fineGrainedScopePartsMatch([passedInScope], allowedScope)
+
+        then:
+        isMatch == true
+
+        where:
+        passedInScope               | allowedScope
+        'r:security:test'           | 'r:security:test'
+        'w:security:test:disarm'    | 'w:security:*:*'
+        'r:security:test'           | 'r:security:*'
+        'r:*:test'                  | 'r:security:test'
+        'r:security:*:*'            | 'r:security:test:disarm'
+    }
+
     private static class NoScope {
         @ScopesAllowed('static')
         @FineGrainedScopesAllowed([@FineGrainedScopeAllowed(scope='{fine}', varInfo=@VarInfo(name='fine', type=HttpRequestVarType.PATH))])


### PR DESCRIPTION
updating bug in Fine Grained Scope check to work properly with *s

Before if an oauth token had access to the scope "r:security:*:disarm" and the endpoint required a scope of "r:security:123-123-1234:disarm" the fine grained scope feature would deny the request. Adding in a check so that if the oauth token has a * it will allow access to any specific replacement for the star